### PR TITLE
feat: call variables in the JavaScript template

### DIFF
--- a/src/evaluateJavascript-helper.js
+++ b/src/evaluateJavascript-helper.js
@@ -1,16 +1,17 @@
-const getPrefixFromHass = (hass) => {
+const getPrefixFromHass = (hass, variables) => {
   const states = hass?.states ?? undefined;
   const user = hass?.user ?? undefined;
   return `
     var states = ${JSON.stringify(states)};
     var user = ${JSON.stringify(user)};
+    var variables = ${JSON.stringify(variables)};
   `;
 };
 
 // eslint-disable-next-line no-eval
 const doEval = (string) => eval(string);
 
-const evaluateJavascript = (config, hass) => {
+const evaluateJavascript = (config, hass, variables = {}) => {
   let prefix = undefined;
   const configKeys = Object.keys(config);
 
@@ -22,7 +23,7 @@ const evaluateJavascript = (config, hass) => {
           evaluateJavascript(config[key][index], hass);
         } else if (key.endsWith("_javascript")) {
           if (prefix === undefined) {
-            prefix = getPrefixFromHass(hass);
+            prefix = getPrefixFromHass(hass, variables);
           }
 
           const keyWithoutJavascript = key.replace("_javascript", "");
@@ -48,7 +49,7 @@ const evaluateJavascript = (config, hass) => {
       evaluateJavascript(config[key], hass);
     } else if (key.endsWith("_javascript")) {
       if (prefix === undefined) {
-        prefix = getPrefixFromHass(hass);
+        prefix = getPrefixFromHass(hass, variables);
       }
 
       const keyWithoutJavascript = key.replace("_javascript", "");

--- a/src/evaluateJavascript-helper.test.js
+++ b/src/evaluateJavascript-helper.test.js
@@ -104,4 +104,18 @@ describe("Given the evaluateConfig function", () => {
       expect(() => evaluateConfig(config)).toThrowError();
     });
   });
+
+  describe("When passing variables", () => {
+    it("should evaluate the javascript with the variables", () => {
+      const config = {
+        saber_count_javascript:
+          "`${variables.saber_count + variables.saber_count}`",
+      };
+
+      evaluateConfig(config, hass, { saber_count: 7 });
+      expect(config).toEqual({
+        saber_count: "14",
+      });
+    });
+  });
 });

--- a/src/evaluteConfig-helper.js
+++ b/src/evaluteConfig-helper.js
@@ -1,5 +1,6 @@
 import evaluateJavascript from "./evaluateJavascript-helper";
 import evaluateVariables from "./evaluateVariables-helper";
+import formatVariables from "./formatVariables-helper";
 
 export default function evaluateConfig(templateConfig, variables, options) {
   let config = evaluateVariables(templateConfig, variables ?? {});
@@ -7,7 +8,12 @@ export default function evaluateConfig(templateConfig, variables, options) {
   const { hasJavascript, hass } = options;
 
   if (hasJavascript && typeof hass !== "undefined") {
-    config = evaluateJavascript(config, hass);
+    const allVariables = {
+      ...formatVariables(templateConfig.default ?? {}),
+      ...formatVariables(variables ?? {}),
+    };
+
+    config = evaluateJavascript(config, hass, allVariables);
   }
 
   return config;


### PR DESCRIPTION
Add the access to the variables from within the JavaScript.
Usage:
```yaml
streamline_templates:
  my_advanced_template: # This is the name of a template
    card:
      type: custom:bubble-card
      name: "[[name]]"
      icon: "mdi:[[icon]]"
      # This entity is a JavaScript expression
      entity_javascript: "variables.entity"
```