### PR TITLE
fix: update hacs installation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ We all use multiple times the same block of configuration across our lovelace co
 
 This method allows you to get updates directly on the HACS main page
 
-1. If HACS is not installed yet, download it following the instructions on [https://hacs.xyz/docs/setup/download](https://hacs.xyz/docs/setup/download/)
+1. If HACS is not installed yet, download it following the instructions on [https://hacs.xyz/docs/use/download/download/](https://hacs.xyz/docs/use/download/download/)
 2. Proceed to the HACS initial configuration following the instructions on [https://hacs.xyz/docs/configuration/basic](https://hacs.xyz/docs/configuration/basic)
-3. On your sidebar go to `HACS` > `Frontend`
-4. Click on the `+` button at the bottom right corner
-5. Now search for `Streamline Card` and then click on the button at the bottom right corner to download it
-6. Go back on your dashboard and click on the icon at the right top corner then on `Edit dashboard`
-7. You can now click on `Add card` in the bottom right corner and search for `Streamline Card`
+3. On your sidebar go to `HACS`
+4. Click on the three dots button at the top right corner then `Custom repositories`
+5. Put the form:
+   - `https://github.com/brunosabot/streamline-card` as the repository
+   - `Dashboard` as the type
+   - Press `Add`
+6. Now search for `Streamline Card` and then click on the button at the bottom right corner to download it
+7. Go back on your dashboard and click on the icon at the right top corner then on `Edit dashboard`
+8. You can now click on `Add card` in the bottom right corner and search for `Streamline Card`
 
 If it's not working, try to clear your browser cache.
 


### PR DESCRIPTION
HACS is slow is the validation of plugins. Here is an updated version of the readme