### PR TITLE
fix: ensure a first hass is set to the child. Fixes #36

### DIFF
--- a/src/streamline-card.js
+++ b/src/streamline-card.js
@@ -26,7 +26,10 @@ import { version } from "../package.json";
     }
 
     updateCardHass() {
-      if (this._isConnected && this._card && this._hass) {
+      if (
+        (this._isConnected && this._card && this._hass) ||
+        (this._hass && this._card.hass === undefined)
+      ) {
         this._card.hass = this._hass;
       }
     }


### PR DESCRIPTION
Set an initial hass even if the card is not mounted.