### PR TITLE
Rough workaround for layout crashes in HA 2025.06

### DIFF
--- a/src/streamline-card.js
+++ b/src/streamline-card.js
@@ -115,12 +115,15 @@ const thrower = (text) => {
     connectedCallback() {
       if (!this._isConnected) {
         this._isConnected = true;
+         this.queueUpdate("config");
+         this.queueUpdate("editMode");
+         this.queueUpdate("hass");
       }
     }
 
-    disconnectedCallback() {
-      this._isConnected = false;
-    }
+    // disconnectedCallback() {
+    //   this._isConnected = false;
+    // }
 
     get editMode() {
       return this._editMode;


### PR DESCRIPTION
See #73 

This is just a dirty workaround that removes `this.queueUpdate` from the `connectedCallback` and checks if `this._isConnected` is false before setting it again. 

While I have not noticed any issues, I'm not certain if this breaks anything else. 