### PR TITLE
Keith sobo manifest plus UI support

### DIFF
--- a/dist/templates/manifest.jason
+++ b/dist/templates/manifest.jason
@@ -1,0 +1,1 @@
+["../streamline_templates.yaml"]


### PR DESCRIPTION
1. Added a manifest file in the templates subdirectory
2. Updated the streamline_templates.js to use the manifest file
3. Files in the manifest file are now pulled in.  Allowing you to have multiple templates files
4. streamline_templates.js has been fixed so that if you edit a card in the UI that uses a file in the manifest the UI rendering works.