### PR TITLE
Close Step 5's Code Block to Fix Step 6's Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ weather_template:
           };
         }
       `;
+```
 
 ### Step 6: Splitting Configuration with !include
 


### PR DESCRIPTION
Step 5 was missing the closing part of the code block. This caused most of step 6 to become consumed into the code block and broke the formatting for step 6 and onward. This pull request fixes that minor mistake.